### PR TITLE
Fix multi headers

### DIFF
--- a/marshalling.go
+++ b/marshalling.go
@@ -83,10 +83,7 @@ func ToStdLibResponse(resp events.APIGatewayProxyResponse) http.Response {
 		Header:     http.Header{},
 	}
 	for k, v := range resp.Headers {
-		headers := strings.Split(v, ",")
-		for _, h := range headers {
-			shr.Header.Add(k, h)
-		}
+		shr.Header.Add(k, v)
 	}
 	return shr
 }

--- a/marshalling.go
+++ b/marshalling.go
@@ -83,7 +83,10 @@ func ToStdLibResponse(resp events.APIGatewayProxyResponse) http.Response {
 		Header:     http.Header{},
 	}
 	for k, v := range resp.Headers {
-		shr.Header.Add(k, v)
+		headers := strings.Split(v, ",")
+		for _, h := range headers {
+			shr.Header.Add(k, h)
+		}
 	}
 	return shr
 }


### PR DESCRIPTION
When you set multiple versions of Set-Cookie they get lost.
Fixing them so they get passed back as separate headers (and not lost)

Solution based on here (and took me embarrassingly long to implement)
https://forums.aws.amazon.com/thread.jspa?threadID=205782