### PR TITLE
add handling of APIGatewayV2HTTPRequest's

### DIFF
--- a/apigateway.go
+++ b/apigateway.go
@@ -66,17 +66,14 @@ func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, er
 
 //RespondvV2 will produce a response that will get formatted such that apigateway will modify it's response to the browser
 func RespondvV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest, err error) (events.APIGatewayV2HTTPResponse, error) {
-	// log.Println("Entering Respond")
 	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
 		log.Println("Unsuported return type")
 	}
-	debug.PrintStack()
 	bodyBytes, jsonerr := json.Marshal(body)
 	if jsonerr != nil {
 		log.Println(jsonerr.Error())
 	}
 	resp := events.APIGatewayV2HTTPResponse{
-		// RequestID:  req.Context.RequestId,
 		StatusCode: status,
 		Body:       fmt.Sprintf("%s", bodyBytes),
 	}
@@ -165,7 +162,6 @@ func (rw *ResponseWriterV2) Header() http.Header {
 }
 
 func (rw *ResponseWriterV2) Write(data []byte) (int, error) {
-	// log.Println("Called ResponseWriter.Write()")
 	return rw.body.Write(data)
 }
 
@@ -267,8 +263,6 @@ func toggleCase(a byte) string {
 
 //ServeV2 handles and responds to the requests using a net/http handler
 func ServeV2(req events.APIGatewayV2HTTPRequest, handler http.Handler) (events.APIGatewayV2HTTPResponse, error) {
-	// log.Println("Entering Serve")
-	// defer func() { log.Println("Exiting Serve") }()
 	shr, err := ToStdLibRequestV2(req)
 	if err != nil {
 		log.Println(err.Error())

--- a/apigateway.go
+++ b/apigateway.go
@@ -64,8 +64,8 @@ func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, er
 	return resp, nil
 }
 
-//RespondvV2 will produce a response that will get formatted such that apigateway will modify it's response to the browser
-func RespondvV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest, err error) (events.APIGatewayV2HTTPResponse, error) {
+//RespondV2 will produce a response that will get formatted such that apigateway will modify it's response to the browser
+func RespondV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest, err error) (events.APIGatewayV2HTTPResponse, error) {
 	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
 		log.Println("Unsuported return type")
 	}
@@ -266,7 +266,7 @@ func ServeV2(req events.APIGatewayV2HTTPRequest, handler http.Handler) (events.A
 	shr, err := ToStdLibRequestV2(req)
 	if err != nil {
 		log.Println(err.Error())
-		return RespondvV2(nil, 500, req, err)
+		return RespondV2(nil, 500, req, err)
 	}
 	rw := ResponseWriterV2{}
 	handler.ServeHTTP(&rw, shr)

--- a/apigateway.go
+++ b/apigateway.go
@@ -64,6 +64,46 @@ func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, er
 	return resp, nil
 }
 
+//RespondvV2 will produce a response that will get formatted such that apigateway will modify it's response to the browser
+func RespondvV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest, err error) (events.APIGatewayV2HTTPResponse, error) {
+	// log.Println("Entering Respond")
+	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
+		log.Println("Unsuported return type")
+	}
+	debug.PrintStack()
+	bodyBytes, jsonerr := json.Marshal(body)
+	if jsonerr != nil {
+		log.Println(jsonerr.Error())
+	}
+	resp := events.APIGatewayV2HTTPResponse{
+		// RequestID:  req.Context.RequestId,
+		StatusCode: status,
+		Body:       fmt.Sprintf("%s", bodyBytes),
+	}
+	if err != nil {
+		if status == 200 {
+			resp.StatusCode = 500
+		}
+		if body == nil {
+			resp.Body = err.Error()
+		}
+		log.Println(err.Error())
+	}
+	if status == 0 {
+		resp.StatusCode = 200
+	}
+	if resp.Body == "null" {
+		resp.Body = ""
+	}
+	resp.Headers = map[string]string{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+		"Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
+		"Content-Type":                 "application/json",
+	}
+	return resp, nil
+}
+
 //RespondHTTP will marshall the response body as JSON and write it to the response writer
 //This function signature was chosen to make it substitutable for http.Error
 //This does not end the requset, but does write the header. Care should be taken to close the response after this has been called
@@ -107,6 +147,49 @@ func RespondHTTP(rw http.ResponseWriter, body interface{}, status int) {
 		rw.WriteHeader(status)
 	}
 	// log.Println("Exiting RespondHTTP")
+}
+
+//ResponseWriterV2 implements the net/http ResponseWriterV2 interface for using stdlib compliant server libraries with apigatewayv2 and lambdas
+type ResponseWriterV2 struct {
+	resp   events.APIGatewayV2HTTPResponse
+	body   bytes.Buffer
+	header http.Header
+}
+
+//Header returns the map that will be sent with WriteHeader
+func (rw *ResponseWriterV2) Header() http.Header {
+	if rw.header == nil {
+		rw.header = make(map[string][]string)
+	}
+	return rw.header
+}
+
+func (rw *ResponseWriterV2) Write(data []byte) (int, error) {
+	// log.Println("Called ResponseWriter.Write()")
+	return rw.body.Write(data)
+}
+
+//WriteHeader sets the response code in the embeded response object
+//To be compliant with the http spec for the interface it should write the headers to the client, but we can't control that
+func (rw *ResponseWriterV2) WriteHeader(status int) {
+	rw.resp.StatusCode = status
+	//can't actually write the headers out before we return :(
+}
+
+//GetResponse formats the net/http response to how the response is expected by apigateway
+func (rw *ResponseWriterV2) GetResponse() (events.APIGatewayV2HTTPResponse, error) {
+	rw.resp.Body = rw.body.String()
+	rw.resp.Headers = make(map[string]string, len(rw.header))
+	for key, values := range rw.header {
+		if strings.ToLower(key) == "set-cookie" {
+			for i, v := range values {
+				rw.resp.Headers[setCookieCasing(i)] = v
+			}
+		} else {
+			rw.resp.Headers[key] = strings.Join(values, ",")
+		}
+	}
+	return rw.resp, nil
 }
 
 //ResponseWriter implements the net/http ResponseWriter interface for using stdlib compliant server libraries with apigateway and lambdas
@@ -182,6 +265,20 @@ func toggleCase(a byte) string {
 
 }
 
+//ServeV2 handles and responds to the requests using a net/http handler
+func ServeV2(req events.APIGatewayV2HTTPRequest, handler http.Handler) (events.APIGatewayV2HTTPResponse, error) {
+	// log.Println("Entering Serve")
+	// defer func() { log.Println("Exiting Serve") }()
+	shr, err := ToStdLibRequestV2(req)
+	if err != nil {
+		log.Println(err.Error())
+		return RespondvV2(nil, 500, req, err)
+	}
+	rw := ResponseWriterV2{}
+	handler.ServeHTTP(&rw, shr)
+	return rw.GetResponse()
+}
+
 //Serve handles and responds to the requests using a net/http handler
 func Serve(req events.APIGatewayProxyRequest, handler http.Handler) (events.APIGatewayProxyResponse, error) {
 	// log.Println("Entering Serve")
@@ -216,12 +313,14 @@ func StartApex(handler http.Handler) {
 	})
 }
 
+//StartLambda ...
 func StartLambda(handler http.Handler, fallback lambdaHandlerFunc) {
 	lambda.Start(LambdaHandler(handler, fallback))
 }
 
 type lambdaHandlerFunc func(event json.RawMessage) (interface{}, error)
 
+//LambdaHandler ...
 func LambdaHandler(handler http.Handler, fallback lambdaHandlerFunc) lambdaHandlerFunc {
 	return func(event json.RawMessage) (interface{}, error) {
 		var err error

--- a/marshalling.go
+++ b/marshalling.go
@@ -43,6 +43,36 @@ func ToStdLibRequest(req events.APIGatewayProxyRequest) (*http.Request, error) {
 	return shr, err
 }
 
+func ToStdLibRequestV2(req events.APIGatewayV2HTTPRequest) (*http.Request, error) {
+	// spew.Fdump(os.Stderr, req)
+	queryString := "?"
+	for key, value := range req.QueryStringParameters {
+		if len(queryString) > 1 {
+			queryString += "&"
+		}
+		queryString += key + "=" + value
+	}
+	shr, err := http.NewRequest(req.RequestContext.HTTP.Method, "https://host"+req.RawPath+queryString, bytes.NewBuffer([]byte(req.Body)))
+	if err != nil {
+		return shr, err
+	}
+
+	shr.Host = req.Headers["Host"]
+	shr.URL.Host = req.Headers["Host"]
+	// If we are on an aws domain, add the request Stage to the host
+	// (as it sneaks into the url path but is not considered in the "Path")
+	if re.MatchString(req.Headers["Host"]) {
+		shr.Host = shr.Host + "/" + req.RequestContext.Stage
+		shr.URL.Host = shr.URL.Host + "/" + req.RequestContext.Stage
+	}
+	shr.URL.Scheme = req.Headers["CloudFront-Forwarded-Proto"]
+	shr.RemoteAddr = req.RequestContext.HTTP.SourceIP
+	for key, values := range req.Headers {
+		shr.Header.Add(key, values)
+	}
+	return shr, err
+}
+
 func ToApigRequest(req http.Request) (events.APIGatewayProxyRequest, error) {
 	apigReq := events.APIGatewayProxyRequest{}
 

--- a/marshalling.go
+++ b/marshalling.go
@@ -44,7 +44,6 @@ func ToStdLibRequest(req events.APIGatewayProxyRequest) (*http.Request, error) {
 }
 
 func ToStdLibRequestV2(req events.APIGatewayV2HTTPRequest) (*http.Request, error) {
-	// spew.Fdump(os.Stderr, req)
 	queryString := "?"
 	for key, value := range req.QueryStringParameters {
 		if len(queryString) > 1 {


### PR DESCRIPTION
Copied the v1 methods but passed in and out the version 2 structs. These seem to be all thats needed for the new spalk-auth-service lambda. It's additive only