### PR TITLE
Notify and return an error if the response body provided to RespondHTTP is too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 -   Fix issue where query parameters with multiple of the same key were not processing more than one of it's values
+-   Notify and return an error if the response body provided to RespondHTTP is too large

--- a/apigateway.go
+++ b/apigateway.go
@@ -17,40 +17,75 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/SpalkLtd/slogger"
+	"github.com/SpalkLtd/slogger/loggers/logentries"
+	"github.com/SpalkLtd/slogger/notifiers/airbrake"
 	apex "github.com/apex/go-apex"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
+const awsLambdaMaxBodySize = 6 * 1000 * 1000 // 6 MB
+
+var logger *slogger.SpalkLogger
+
+func init() {
+	env := os.Getenv("ENVIRONMENT")
+	if env == "" {
+		env = "dev"
+	}
+	logger = slogger.NewLogger()
+	logHost := os.Getenv("LS_LOG_HOST")
+	logToken := os.Getenv("LS_LOG_TOKEN")
+	if logHost != "" && logToken != "" {
+		// Note call depth offset here: should tell us which apig.RespondHTTP call caused any errors
+		leLogger, err := logentries.New(logHost, logToken, 0, nil, 1)
+		if err == nil {
+			logger.SetLogger(leLogger)
+		} else {
+			logger.SetDefaultLogger()
+			logger.WithError(err).Println()
+		}
+	} else {
+		logger.SetDefaultLogger()
+	}
+	logger.Logger.SetFlags(log.Ltime | log.Lmicroseconds | log.Lshortfile)
+
+	errbitHost := os.Getenv("ERRBIT_HOST")
+	errbitKey := os.Getenv("ERRBIT_API_KEY")
+	if errbitHost != "" && errbitKey != "" {
+		logger.Notifier = airbrake.New(errbitHost, errbitKey, env, 1234)
+	}
+	logger.SetTag("environment", env)
+}
+
 var ErrNoHandler = errors.New("No handler defined for event of that type")
 
 //Respond will produce a response that will get formatted such that apigateway will modify it's response to the browser
 func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, err error) (events.APIGatewayProxyResponse, error) {
-	// log.Println("Entering Respond")
 	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
-		log.Println("Unsuported return type")
+		logger.Println("Unsuported return type")
 	}
 	debug.PrintStack()
 	bodyBytes, jsonerr := json.Marshal(body)
 	if jsonerr != nil {
-		log.Println(jsonerr.Error())
+		logger.Println(jsonerr.Error())
 	}
 	resp := events.APIGatewayProxyResponse{
-		// RequestID:  req.Context.RequestId,
 		StatusCode: status,
 		Body:       fmt.Sprintf("%s", bodyBytes),
 	}
 	if err != nil {
-		if status == 200 {
-			resp.StatusCode = 500
+		if status == http.StatusOK {
+			resp.StatusCode = http.StatusInternalServerError
 		}
 		if body == nil {
 			resp.Body = err.Error()
 		}
-		log.Println(err.Error())
+		logger.Println(err.Error())
 	}
 	if status == 0 {
-		resp.StatusCode = 200
+		resp.StatusCode = http.StatusOK
 	}
 	if resp.Body == "null" {
 		resp.Body = ""
@@ -67,27 +102,27 @@ func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, er
 //RespondV2 will produce a response that will get formatted such that apigateway will modify it's response to the browser
 func RespondV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest, err error) (events.APIGatewayV2HTTPResponse, error) {
 	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
-		log.Println("Unsuported return type")
+		logger.Println("Unsuported return type")
 	}
 	bodyBytes, jsonerr := json.Marshal(body)
 	if jsonerr != nil {
-		log.Println(jsonerr.Error())
+		logger.Println(jsonerr.Error())
 	}
 	resp := events.APIGatewayV2HTTPResponse{
 		StatusCode: status,
 		Body:       fmt.Sprintf("%s", bodyBytes),
 	}
 	if err != nil {
-		if status == 200 {
-			resp.StatusCode = 500
+		if status == http.StatusOK {
+			resp.StatusCode = http.StatusInternalServerError
 		}
 		if body == nil {
 			resp.Body = err.Error()
 		}
-		log.Println(err.Error())
+		logger.Println(err.Error())
 	}
 	if status == 0 {
-		resp.StatusCode = 200
+		resp.StatusCode = http.StatusOK
 	}
 	if resp.Body == "null" {
 		resp.Body = ""
@@ -105,45 +140,52 @@ func RespondV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest,
 //This function signature was chosen to make it substitutable for http.Error
 //This does not end the requset, but does write the header. Care should be taken to close the response after this has been called
 func RespondHTTP(rw http.ResponseWriter, body interface{}, status int) {
-	// log.Println("Entering RespondHTTP")
 	if body != nil {
 		if reflect.TypeOf(body).Kind() == reflect.Func {
-			log.Println("Unsuported return type")
+			logger.Println("Unsuported return type")
 			debug.PrintStack()
 			return
 		}
 		if err, ok := body.(error); ok {
 			if status < 400 {
-				status = 500
+				status = http.StatusInternalServerError
 			}
-			log.Printf("Writing %v", err.Error())
+			logger.Printf("Writing %v", err.Error())
 			http.Error(rw, err.Error(), status)
 			return
 		}
 		var bodyBytes []byte
-		if bodyString, ok := body.(string); ok {
+		if bb, ok := body.([]byte); ok {
+			bodyBytes = bb
+		} else if bodyString, ok := body.(string); ok {
 			bodyBytes = []byte(bodyString)
 		} else {
 			jsonBytes, jsonerr := json.Marshal(body)
 			if jsonerr != nil {
-				log.Println(jsonerr.Error())
+				logger.Println(jsonerr.Error())
 				http.Error(rw, "Error marshalling reponse", http.StatusInternalServerError)
 			}
 			bodyBytes = jsonBytes
 		}
+		if len(bodyBytes) > awsLambdaMaxBodySize {
+			errMsg := fmt.Sprintf("Response body too large: %d", len(bodyBytes))
+			logger.Println(errMsg)
+			logger.NotifyAdmin(errMsg, nil)
+			http.Error(rw, "Response body too large", http.StatusInternalServerError)
+			return
+		}
 		rw.WriteHeader(status)
 		written, err := rw.Write(bodyBytes)
 		if err != nil {
-			log.Println(err.Error())
+			logger.Println(err.Error())
 		}
 		if written != len(bodyBytes) {
-			log.Println("Unable to finish writing body: " + string(bodyBytes))
+			logger.Println("Unable to finish writing body: " + string(bodyBytes))
 		}
 	} else {
 		rw.Header().Set("Content-Type", "plaintext")
 		rw.WriteHeader(status)
 	}
-	// log.Println("Exiting RespondHTTP")
 }
 
 //ResponseWriterV2 implements the net/http ResponseWriterV2 interface for using stdlib compliant server libraries with apigatewayv2 and lambdas
@@ -204,7 +246,6 @@ func (rw *ResponseWriter) Header() http.Header {
 }
 
 func (rw *ResponseWriter) Write(data []byte) (int, error) {
-	// log.Println("Called ResponseWriter.Write()")
 	return rw.body.Write(data)
 }
 
@@ -265,8 +306,8 @@ func toggleCase(a byte) string {
 func ServeV2(req events.APIGatewayV2HTTPRequest, handler http.Handler) (events.APIGatewayV2HTTPResponse, error) {
 	shr, err := ToStdLibRequestV2(req)
 	if err != nil {
-		log.Println(err.Error())
-		return RespondV2(nil, 500, req, err)
+		logger.Println(err.Error())
+		return RespondV2(nil, http.StatusInternalServerError, req, err)
 	}
 	rw := ResponseWriterV2{}
 	handler.ServeHTTP(&rw, shr)
@@ -275,12 +316,10 @@ func ServeV2(req events.APIGatewayV2HTTPRequest, handler http.Handler) (events.A
 
 //Serve handles and responds to the requests using a net/http handler
 func Serve(req events.APIGatewayProxyRequest, handler http.Handler) (events.APIGatewayProxyResponse, error) {
-	// log.Println("Entering Serve")
-	// defer func() { log.Println("Exiting Serve") }()
 	shr, err := ToStdLibRequest(req)
 	if err != nil {
-		log.Println(err.Error())
-		return Respond(nil, 500, req, err)
+		logger.Println(err.Error())
+		return Respond(nil, http.StatusInternalServerError, req, err)
 	}
 	rw := ResponseWriter{}
 	handler.ServeHTTP(&rw, shr)
@@ -292,8 +331,8 @@ func StartApex(handler http.Handler) {
 	apex.HandleFunc(func(event json.RawMessage, ctx *apex.Context) (interface{}, error) {
 		var req events.APIGatewayProxyRequest
 		if err := json.Unmarshal(event, &req); err != nil {
-			log.Println(err.Error())
-			log.Println(string(event))
+			logger.Println(err.Error())
+			logger.Println(string(event))
 			return Respond(nil, 401, req, err)
 		}
 		for k, v := range req.StageVariables {
@@ -301,7 +340,7 @@ func StartApex(handler http.Handler) {
 		}
 		resp, err := Serve(req, handler)
 		if err != nil {
-			log.Println(err.Error())
+			logger.Println(err.Error())
 		}
 		return resp, err
 	})
@@ -325,7 +364,7 @@ func LambdaHandler(handler http.Handler, fallback lambdaHandlerFunc) lambdaHandl
 			}
 			resp, err := Serve(apigEvent, handler)
 			if err != nil {
-				log.Println(err.Error())
+				logger.Println(err.Error())
 			}
 			return resp, err
 		}

--- a/apigateway.go
+++ b/apigateway.go
@@ -11,8 +11,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"reflect"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"unicode"
@@ -63,10 +61,6 @@ var ErrNoHandler = errors.New("No handler defined for event of that type")
 
 //Respond will produce a response that will get formatted such that apigateway will modify it's response to the browser
 func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, err error) (events.APIGatewayProxyResponse, error) {
-	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
-		logger.Println("Unsuported return type")
-	}
-	debug.PrintStack()
 	bodyBytes, jsonerr := json.Marshal(body)
 	if jsonerr != nil {
 		logger.Println(jsonerr.Error())
@@ -101,9 +95,6 @@ func Respond(body interface{}, status int, req events.APIGatewayProxyRequest, er
 
 //RespondV2 will produce a response that will get formatted such that apigateway will modify it's response to the browser
 func RespondV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest, err error) (events.APIGatewayV2HTTPResponse, error) {
-	if body != nil && reflect.TypeOf(body).Kind() == reflect.Func {
-		logger.Println("Unsuported return type")
-	}
 	bodyBytes, jsonerr := json.Marshal(body)
 	if jsonerr != nil {
 		logger.Println(jsonerr.Error())
@@ -141,11 +132,6 @@ func RespondV2(body interface{}, status int, req events.APIGatewayV2HTTPRequest,
 //This does not end the requset, but does write the header. Care should be taken to close the response after this has been called
 func RespondHTTP(rw http.ResponseWriter, body interface{}, status int) {
 	if body != nil {
-		if reflect.TypeOf(body).Kind() == reflect.Func {
-			logger.Println("Unsuported return type")
-			debug.PrintStack()
-			return
-		}
 		if err, ok := body.(error); ok {
 			if status < 400 {
 				status = http.StatusInternalServerError

--- a/apigateway_test.go
+++ b/apigateway_test.go
@@ -241,9 +241,9 @@ func TestToApigRequestMultiQuery(t *testing.T) {
 	apgReq, err := apig.ToApigRequest(*req)
 	require.NoError(t, err)
 	require.Equal(t, map[string][]string{
-		"page":         []string{"0"},
-		"pageSize":     []string{"20"},
-		"reviewFilter": []string{"2", "5", "4"},
+		"page":         {"0"},
+		"pageSize":     {"20"},
+		"reviewFilter": {"2", "5", "4"},
 	}, apgReq.MultiValueQueryStringParameters)
 }
 

--- a/expose_test.go
+++ b/expose_test.go
@@ -1,0 +1,7 @@
+package apig
+
+import "github.com/SpalkLtd/slogger"
+
+func SetLogger(testLogger *slogger.SpalkLogger) {
+	logger = testLogger
+}

--- a/expose_test.go
+++ b/expose_test.go
@@ -1,7 +1,0 @@
-package apig
-
-import "github.com/SpalkLtd/slogger"
-
-func SetLogger(testLogger *slogger.SpalkLogger) {
-	logger = testLogger
-}


### PR DESCRIPTION
Also a few general tidy-ups (deleting commented-out code, using HTTP constants). Also errors in this case, which I think is appropriate, as this should make the errors easier to diagnose than more-insidious JSON-parsing failures on the front end.